### PR TITLE
Removed last references to point3A.jpg

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,12 +138,6 @@ def main():
     datainfo['reference'] = 'Wandrille Duchemin (University of Basel & SIB Swiss Institute of Bioinformatics), Barcode Of Life Database'
     datainfo['author'] = 'Brian Abbott (American Museum of Natural History, New York), Wandrille Duchemin (University of Basel & SIB Swiss Institute of Bioinformatics), Jackie Faherty (American Museum of Natural History, New York), David Thaler (University of Basel, Switzerland & Rockefeller University, New York)'
 
-
-    # Copy the viz assets file to each subproject folder.Define the path to the source file here.
-    # sourcePath = Path.cwd() / 'viz_assets' / 'point3A.png'
-    
-
-
     # Make the color table
     # (This is commented out because it's run once, but it's here for completeness)
     # -----------------------------------------------------------------------------------

--- a/src/human_origins.py
+++ b/src/human_origins.py
@@ -613,10 +613,6 @@ def make_asset_all(datainfo):
         
 
 
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
-
         print('-- Set some parameters for OpenSpace settings')
         print('local point_scale_factor = ' + common.HUMAN_POINT_SCALE_FACTOR)
         print('local point_scale_exponent = ' + common.HUMAN_POINT_SCALE_EXPONENT)
@@ -821,8 +817,6 @@ def make_asset_regions(datainfo):
 
 
         print('local ' + asset_info[file]['cmap_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['cmap_file'] + '")')
-        print()
-        print('local texture_file = asset.resource("point3A.png")')
         print()
 
 

--- a/src/sequence.py
+++ b/src/sequence.py
@@ -398,10 +398,6 @@ def make_asset(datainfo):
             #print('local color_file = asset.resource("' + asset_info[file]['cmap_file'] + '")')
 
 
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
-
         print('-- Set some parameters for OpenSpace settings')
         print('local scale_factor = ' + common.POINT_SCALE_FACTOR)
         print('local scale_exponent = ' + common.POINT_SCALE_EXPONENT)

--- a/src/sequence_lineage.py
+++ b/src/sequence_lineage.py
@@ -395,9 +395,6 @@ def make_asset(datainfo):
             print('local ' + asset_info[file]['label_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['label_file'] + '")')
 
             print('local ' + asset_info[file]['cmap_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['cmap_file'] + '")')
-
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
         
 
 

--- a/src/slice_by_clade.py
+++ b/src/slice_by_clade.py
@@ -210,11 +210,7 @@ def make_asset(datainfo):
         print('-- Set file paths')
         for file in asset_info:
             print('local ' + asset_info[file]['speck_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['speck_file'] + '")')
-
         print()
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
 
         print('-- Set some parameters for OpenSpace settings')
         print('local scale_factor = '   + common.POINT_SCALE_FACTOR)

--- a/src/slice_by_lineage.py
+++ b/src/slice_by_lineage.py
@@ -281,9 +281,6 @@ def make_asset(datainfo, taxon):
             print('local ' + asset_info[file]['speck_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['speck_file'] + '")')
 
         print()
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
 
         print('-- Set some parameters for OpenSpace settings')
         print('local scale_factor = ' + common.POINT_SCALE_FACTOR)

--- a/src/slice_by_taxon.py
+++ b/src/slice_by_taxon.py
@@ -182,9 +182,6 @@ def make_asset(datainfo):
             print('local ' + asset_info[file]['speck_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['speck_file'] + '")')
 
         print()
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
 
         print('-- Set some parameters for OpenSpace settings')
         print('local scale_factor = ' + common.POINT_SCALE_FACTOR)

--- a/src/takanori_trials.py
+++ b/src/takanori_trials.py
@@ -232,13 +232,6 @@ def make_asset(datainfo):
 
         print('local ' + asset_info[file]['cmap_var'] + ' = asset.resource("' + asset_info[file]['cmap_file'] + '")')
 
-
-        print('local texture_file = asset.resource("point3A.png")')
-        print()
-
-
-
-
         print('-- Set some parameters for OpenSpace settings')
         print('local scale_factor = ' + common.POINT_SCALE_FACTOR)
         print('local scale_exponent = ' + common.POINT_SCALE_EXPONENT)


### PR DESCRIPTION
- We use RenderablePointCloud for all of these assets now, and don't need to carry around the "sprite" for this.