### PR TITLE
Internal node labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -341,7 +341,8 @@ def primates(datainfo, vocab):
 
     meta_data = metadata.process_data(datainfo)
 
-    # HH - The consensus points are a single point for each species. This is most likely the centroid or something like that; I need to look into this more.
+    # HH - The consensus points are a single point for each species. This is most likely
+    # the centroid or something like that; I need to look into this more.
     consensus = consensus_species.process_data(datainfo, vocab)
     consensus_species.make_asset(datainfo)
 
@@ -355,12 +356,22 @@ def primates(datainfo, vocab):
     # Make a new tree object
     mytree = tree.tree()
 
-    # Process the tree of primates
-    # NOTE: need to run the ./catalogs_raw/primates/tree/integrate_tree_to_XYZ.py, see the readme file there.
+    # Process the tree of primates NOTE: need to run the
+    # ./catalogs_raw/primates/tree/integrate_tree_to_XYZ.py, see the readme file there.
+    # This is a bit hacky in that each part of the tree is handled manually here (leaves,
+    # branches, clades), whereas optimally this would all be taken care of in the tree
+    # class.
     mytree.process_leaves(datainfo)
     mytree.make_asset_leaves(datainfo)
     mytree.process_branches(datainfo)
     mytree.make_asset_branches(datainfo)
+    mytree.process_internal(datainfo)
+    mytree.make_asset_internal(datainfo)
+
+    # The interpolated points are kinda-sorta associated with the tree, but not really.
+    # They are a separate set of points that are interpolated from the leaf points to the
+    # data-reduction points. This is to show the relationship between the established
+    # evolutionary relationships and the data-reduced points.
     mytree.process_leaves_interpolated(datainfo)
     mytree.make_asset_leaves_interpolated(datainfo)
 

--- a/main.py
+++ b/main.py
@@ -179,6 +179,9 @@ def main():
         datainfo['seq2taxon_file'] = 'primates.seqId2taxon.csv'
         datainfo['synonomous_file'] = 'primates.syn.nonsyn.distToHumanConsensus.csv'
         datainfo['lineage_columns'] = [24, 31]
+        datainfo['tree_leaves_file'] = 'primates.leaves.csv'
+        datainfo['tree_branches_file'] = 'primates.branches.csv'
+        datainfo['tree_internal_file'] = 'primates.internal.csv'
         primates(datainfo, vocab)
 
         """

--- a/src/tree.py
+++ b/src/tree.py
@@ -1,10 +1,14 @@
 '''
 Cosmic View of Life on Earth
 
-Process the tree of primates which makes the points and the lines that
-represent the evolution.
+Tree processing code. Trees are comprised of 3 elements:
+1. Leaves: The current day species/taxon
+2. Clades: The internal branch points, which represent the hypothetical common ancestor of a group of species.
+3. Branches: The lines that connect the leaves and clades.
 
-Author: Brian Abbott <abbott@amnh.org>
+Assets are created for each of these elements. Some assets have multiple files, some are CSV and some are speck.
+
+Author: Brian Abbott <abbott@amnh.org>, Hollister Herhold <hherhold@amnh.org>
 Created: June 2023
 '''
 
@@ -16,6 +20,15 @@ from pathlib import Path
 from src import common
 
 class tree:
+    '''
+    This class processes tree data for the Cosmic View of Life on Earth project. Trees are 
+    comprised of 3 elements:
+    1. Leaves: The current day species/taxon
+    2. Clades: The internal branch points, which represent the hypothetical common ancestor of a group of species.
+    3. Branches: The lines that connect the leaves and clades.
+
+    These three elements are processed separately, with .csv files for the clades and leaves, and a .speck file for the branches.
+    '''
 
     def __init__(self):
 
@@ -24,30 +37,25 @@ class tree:
 
     def process_leaves(self, datainfo):
         '''
-        Process the primate tree of life points. These consist of "leaves" which are the 
-        present day species/taxon, and the internal branch points, which are the nexus
-        of common ancestors, all the way down to the one common ancestor of all primates.
+        Process the tree leaves csv file. This file contains the current day species/taxon. 
 
         Input:
             dict(datainfo)
 
         Output:
-            .speck
+            .csv
         '''
 
-        common.print_subhead_status('Processing Primate tree data')
+        common.print_subhead_status('Processing tree data - leaves')
 
-
-
-        
         # Generate the Consensus points for the tree. These will be points that sit on the tips
         # of the tree branches -- the leaves.
         # ------------------------------------------------------------------------------------------
         datainfo['data_group_title'] = datainfo['sub_project'] + ': Consensus Tree'
-        datainfo['data_group_desc'] = 'Data points for the primate consensus tree.'
+        datainfo['data_group_desc'] = 'Data points for the tree - leaves.'
 
-        # These are the "leaves"--the current day species.
-        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / 'primates.leaves.csv'
+        # These are the "leaves"--the current day (extant) species.
+        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / datainfo['tree_leaves_file']
         common.test_input_file(inpath)
 
         leaves = pd.read_csv(inpath)
@@ -67,7 +75,7 @@ class tree:
         outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
         common.test_path(outpath)
 
-        outfile_csv = 'primates_leaves.csv'
+        outfile_csv = datainfo['dir'] + '_leaves.csv'
         outpath_csv = outpath / outfile_csv
         
 
@@ -83,11 +91,71 @@ class tree:
         # Report to stdout
         common.out_file_message(outpath_csv)
 
+    def process_clades(self, datainfo):
+        '''
+        Process the tree clades csv file. This file contains the internal branch points of the tree.
+        Not all of these are to be displayed - many are simply internal branch points and do not have
+        named clades. These are named "internalXX" where XX is a number. (It may have more than two digits,
+        or only have one. It depends on the number of internal branch points.)
+
+        The only points that are displayed are those that have a name. These are the clades.
+
+        Input:
+            dict(datainfo)
+
+        Output:
+            .speck
+        '''
+
+        common.print_subhead_status('Processing tree data - clades')
+
+        # Generate the Consensus points for the tree. These will be points that sit on the tips
+        # of the tree branches -- the leaves.
+        # ------------------------------------------------------------------------------------------
+        datainfo['data_group_title'] = datainfo['sub_project'] + ': Consensus Tree'
+        datainfo['data_group_desc'] = 'Data points for the tree - leaves.'
+
+        # These are the "leaves"--the current day (extant) species.
+        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / datainfo['tree_internal_file']
+        common.test_input_file(inpath)
+
+        leaves = pd.read_csv(inpath)
+
+        # Rearrange the columns
+        leaves = leaves[['x', 'y', 'z', 'name']]
+
+        # Add underscores to the taxon names
+        leaves['name'] = leaves['name'].str.replace(' ', '_')
+
+        # Move the z values down
+        leaves.loc[:, 'z'] = leaves['z'].apply(lambda x: x - common.TRANSFORM_TREE_Z * 2.15)
+        #print(leaves)
+
+
+        # Write data to files
+        outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
+        common.test_path(outpath)
+
+        outfile_csv = datainfo['dir'] + '_internal.csv'
+        outpath_csv = outpath / outfile_csv
+        
+
+        with open(outpath_csv, 'w') as csvfile:
+
+            datainfo['author'] = 'Brian Abbott (American Museum of Natural History, New York), Wandrille Duchemin (University of Basel & SIB Swiss Institute of Bioinformatics), Robin Ridell (Univ Linköping), Märta Nilsson (Univ Linköping)'
+
+            header = common.header(datainfo, script_name=Path(__file__).name)
+            print(header, file=csvfile)
+
+            leaves.to_csv(csvfile, index=False, lineterminator='\n')
+            
+        # Report to stdout
+        common.out_file_message(outpath_csv)
         
 
     def process_leaves_interpolated(self, datainfo):
         '''
-        Process the primate tree of life points that can be interpolated. These are
+        Process the tree points that can be interpolated. These are
         A. the consensus points that are placed in XYZ space as a result of
             indicator vector computation and data reduction
         B. The leaves of the tree, along with the tree, which indicate 
@@ -107,16 +175,16 @@ class tree:
             second set is the consensus points at t=1.
         '''
 
-        common.print_subhead_status('Processing Primate tree data')
+        common.print_subhead_status('Processing tree data - interpolated')
 
         # Generate the Consensus points for the tree. These will be points that sit on the tips
         # of the tree branches -- the leaves.
         # ------------------------------------------------------------------------------------------
         datainfo['data_group_title'] = datainfo['sub_project'] + ': Consensus Tree'
-        datainfo['data_group_desc'] = 'Interpolatable points for the primate consensus tree.'
+        datainfo['data_group_desc'] = 'Interpolatable points for the tree.'
 
         # These are the "leaves"--the current day species.
-        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / 'primates.leaves.csv'
+        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / datainfo['tree_leaves_file']
         common.test_input_file(inpath)
 
         # The data is in the format of x, y, z, name.
@@ -165,7 +233,7 @@ class tree:
         outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
         common.test_path(outpath)
 
-        outfile_csv = 'primates_interpolated.csv'
+        outfile_csv = datainfo['dir'] + '_interpolated.csv'
         outpath_csv = outpath / outfile_csv
         
         with open(outpath_csv, 'wt') as csvfile:
@@ -202,21 +270,21 @@ class tree:
 
     def process_branches(self, datainfo):
         '''
-        Create the lines (branches) for the primate tree of life.
+        Create the lines (branches) for a tree.
         This creates a file of "mesh" statements, used to draw the lines, and
         a dat file that OpenSpace needs to attach each line with an identifier.
 
         Input: 
             dict(datainfo)
-            primates.branches.csv: file with the pairs of points that make up each line
+            datainfo['dir'].branches.csv: file with the pairs of points that make up each line
 
         Output:
-            primate_branches.speck: Series of "mesh" commands that will draw a line in OpenSpace.
-            primate_branches.dat: a "key" file that is used by OpenSpace under the hood.
+            datainfo['dir']_branches.speck: Series of "mesh" commands that will draw a line in OpenSpace.
+            datainfo['dir']_branches.dat: a "key" file that is used by OpenSpace under the hood.
         '''
 
 
-        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / 'primates.branches.csv'
+        inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / datainfo['tree_branches_file']
         common.test_input_file(inpath)
 
         branch_lines = pd.read_csv(inpath)
@@ -239,9 +307,9 @@ class tree:
         outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
         common.test_path(outpath)
 
-        outfile_speck = 'primates_branches.speck'
+        outfile_speck = datainfo['dir'] + '_branches.speck'
         outpath_speck = outpath / outfile_speck
-        outfile_dat = 'primates_branches.dat'
+        outfile_dat = datainfo['dir'] + '_branches.dat'
         outpath_dat = outpath / outfile_dat
 
         with open(outpath_speck, 'wt') as speck, open(outpath_dat, 'wt') as dat:
@@ -276,13 +344,13 @@ class tree:
 
     def make_asset_branches(self, datainfo):
         '''
-        Generate the asset file for the primate tree of life.
+        Generate the asset file for the tree.
         
         Input: 
             dict(datainfo)
 
         Output:
-            primate_branches.asset
+            datainfo['dir']_branches.asset
         '''
 
         # We shift the stdout to our filehandle so that we don't have to keep putting
@@ -308,12 +376,11 @@ class tree:
         #for path in files:
             
         file = path.name
-        #file = 'primates_branches.speck'
 
         # Set the nested dict
         asset_info[file] = {}
 
-        asset_info[file]['speck_file'] = 'primates_branches.speck'
+        asset_info[file]['speck_file'] = datainfo['dir'] + '_branches.speck'
         
         #print(asset_info[file]['speck_file'], path, path.name)
         asset_info[file]['speck_var'] = common.file_variable_generator(asset_info[file]['speck_file'])
@@ -324,7 +391,7 @@ class tree:
         #asset_info[file]['cmap_file'] = path.stem + '.cmap'
         #asset_info[file]['cmap_var'] = common.file_variable_generator(asset_info[file]['cmap_file'])
 
-        asset_info[file]['dat_file'] = 'primates_branches.dat'
+        asset_info[file]['dat_file'] = datainfo['dir'] + '_branches.dat'
         asset_info[file]['dat_var'] = common.file_variable_generator(asset_info[file]['dat_file'])
 
         asset_info[file]['asset_rel_path'] = '.'
@@ -423,13 +490,13 @@ class tree:
 
     def make_asset_leaves(self, datainfo):
         '''
-        Generate the asset file for the primate tree of life data.
+        Generate the asset file for the tree.
         
         Input: 
             dict(datainfo)
 
         Output:
-            primate_branches_leaves.asset
+            datainfo['dir']_branches_leaves.asset
         '''
 
         # We shift the stdout to our filehandle so that we don't have to keep putting
@@ -459,7 +526,7 @@ class tree:
         # Set the nested dict
         asset_info[file] = {}
 
-        asset_info[file]['csv_file'] = 'primates_leaves.csv'
+        asset_info[file]['csv_file'] = datainfo['dir'] + '_leaves.csv'
         asset_info[file]['csv_var'] = common.file_variable_generator(asset_info[file]['csv_file'])
 
         #asset_info[file]['label_file'] = path.stem + '.label'
@@ -584,13 +651,13 @@ class tree:
 
     def make_asset_leaves_interpolated(self, datainfo):
         '''
-        Generate the asset file for the primate tree of life data.
+        Generate the asset file for the tree.
         
         Input: 
             dict(datainfo)
 
         Output:
-            primates_interpolated.asset
+            datainfo['dir']_interpolated.asset
         '''
 
         # We shift the stdout to our filehandle so that we don't have to keep putting
@@ -609,7 +676,7 @@ class tree:
         # Set the nested dict
         asset_info[file] = {}
 
-        asset_info[file]['csv_file'] = 'primates_interpolated.csv'
+        asset_info[file]['csv_file'] = datainfo['dir'] + '_interpolated.csv'
         asset_info[file]['csv_var'] = common.file_variable_generator(asset_info[file]['csv_file'])
 
         #asset_info[file]['label_file'] = path.stem + '.label'

--- a/src/tree.py
+++ b/src/tree.py
@@ -21,13 +21,15 @@ from src import common
 
 class tree:
     '''
-    This class processes tree data for the Cosmic View of Life on Earth project. Trees are 
-    comprised of 3 elements:
+    This class processes tree data for the Cosmic View of Life on Earth project. Trees are
+    comprised of 3 elements: 
     1. Leaves: The current day species/taxon
-    2. Clades: The internal branch points, which represent the hypothetical common ancestor of a group of species.
+    2. Clades: The internal branch points, which represent the hypothetical common
+       ancestor of a group of species.
     3. Branches: The lines that connect the leaves and clades.
 
-    These three elements are processed separately, with .csv files for the clades and leaves, and a .speck file for the branches.
+    These three elements are processed separately, with .csv files for the clades and
+    leaves, and a .speck file for the branches.
     '''
 
     def __init__(self):
@@ -37,7 +39,8 @@ class tree:
 
     def process_leaves(self, datainfo):
         '''
-        Process the tree leaves csv file. This file contains the current day species/taxon. 
+        Process the tree leaves csv file. This file contains the current day
+        species/taxon. 
 
         Input:
             dict(datainfo)
@@ -48,8 +51,8 @@ class tree:
 
         common.print_subhead_status('Processing tree data - leaves')
 
-        # Generate the Consensus points for the tree. These will be points that sit on the tips
-        # of the tree branches -- the leaves.
+        # Generate the Consensus points for the tree. These will be points that sit on the
+        # tips of the tree branches -- the leaves.
         # ------------------------------------------------------------------------------------------
         datainfo['data_group_title'] = datainfo['sub_project'] + ': Consensus Tree'
         datainfo['data_group_desc'] = 'Data points for the tree - leaves.'
@@ -91,14 +94,13 @@ class tree:
         # Report to stdout
         common.out_file_message(outpath_csv)
 
-    def process_clades(self, datainfo):
+    def process_internal(self, datainfo):
         '''
-        Process the tree clades csv file. This file contains the internal branch points of the tree.
-        Not all of these are to be displayed - many are simply internal branch points and do not have
-        named clades. These are named "internalXX" where XX is a number. (It may have more than two digits,
-        or only have one. It depends on the number of internal branch points.)
-
-        The only points that are displayed are those that have a name. These are the clades.
+        Process the tree clades csv file. This file contains the internal branch points of
+        the tree. Not all of these are to be displayed - many are simply internal branch
+        points and do not have named clades. These are named "internalXX" where XX is a
+        number. (It may have more than two digits, or only have one. It depends on the
+        number of internal branch points.)
 
         Input:
             dict(datainfo)
@@ -107,30 +109,28 @@ class tree:
             .speck
         '''
 
-        common.print_subhead_status('Processing tree data - clades')
+        common.print_subhead_status('Processing tree data - internal/clades')
 
-        # Generate the Consensus points for the tree. These will be points that sit on the tips
-        # of the tree branches -- the leaves.
-        # ------------------------------------------------------------------------------------------
         datainfo['data_group_title'] = datainfo['sub_project'] + ': Consensus Tree'
-        datainfo['data_group_desc'] = 'Data points for the tree - leaves.'
+        datainfo['data_group_desc'] = 'Data points for the tree - internal nodes (clades).'
 
-        # These are the "leaves"--the current day (extant) species.
         inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / common.TREE_DIRECTORY / datainfo['tree_internal_file']
         common.test_input_file(inpath)
 
-        leaves = pd.read_csv(inpath)
+        nodes = pd.read_csv(inpath)
+
+        # Discard the internal nodes that start with 'internal' and have no name.
+        nodes = nodes[nodes['name'].str.contains('internal') == False]
 
         # Rearrange the columns
-        leaves = leaves[['x', 'y', 'z', 'name']]
+        nodes = nodes[['x', 'y', 'z', 'name']]
 
         # Add underscores to the taxon names
-        leaves['name'] = leaves['name'].str.replace(' ', '_')
+        nodes['name'] = nodes['name'].str.replace(' ', '_')
 
         # Move the z values down
-        leaves.loc[:, 'z'] = leaves['z'].apply(lambda x: x - common.TRANSFORM_TREE_Z * 2.15)
-        #print(leaves)
-
+        nodes.loc[:, 'z'] = nodes['z'].apply(lambda x: x - common.TRANSFORM_TREE_Z)
+        nodes.loc[:, 'z'] = nodes['z'].apply(lambda x: x * common.SCALE_TREE_Z)
 
         # Write data to files
         outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
@@ -147,7 +147,7 @@ class tree:
             header = common.header(datainfo, script_name=Path(__file__).name)
             print(header, file=csvfile)
 
-            leaves.to_csv(csvfile, index=False, lineterminator='\n')
+            nodes.to_csv(csvfile, index=False, lineterminator='\n')
             
         # Report to stdout
         common.out_file_message(outpath_csv)
@@ -199,17 +199,21 @@ class tree:
         leaves['name'] = leaves['name'].str.replace(' ', '_')
 
         # Move the z values down. This is all of the transforms that are applied to the
-        # non-interpolated data, also called the "tabletop" points that sit at the tips of the tree.
+        # non-interpolated data, also called the "tabletop" points that sit at the tips of
+        # the tree.
         leaves.loc[:, 'z'] = leaves['z'].apply(lambda x: x - common.TRANSFORM_TREE_Z * 2.15)
 
-        # Next load in the consensus points. Note that these do not get scaled or transformed as they're 
-        # already in the correct position (which we want to interpolate to).
+        # Next load in the consensus points. Note that these do not get scaled or
+        # transformed as they're already in the correct position (which we want to
+        # interpolate to).
         # ------------------------------------------------------------------------------------------
-        # Architecturally, this is a little bit of a hack. We're going to read in the consensus points
-        # which are actually processed in consensus_species.py, and we need to read them here and
-        # do the exact same processing as done in consensus_species.py. Ideally we'd be able to ask consensus_species.py
-        # what the processed data is, but that's a bit of a pain. So we're going to read in the data here and do the same
-        # processing. This is a bit of a hack, but it's the best we can do for now.
+        # Architecturally, this is a little bit of a hack. We're going to read in the
+        # consensus points which are actually processed in consensus_species.py, and we
+        # need to read them here and do the exact same processing as done in
+        # consensus_species.py. Ideally we'd be able to ask consensus_species.py what the
+        # processed data is, but that's a bit of a pain. So we're going to read in the
+        # data here and do the same processing. This is a bit of a hack, but it's the best
+        # we can do for now.
         inpath = Path.cwd() / common.DATA_DIRECTORY / datainfo['dir'] / datainfo['catalog_directory'] / datainfo['consensus_file']
         common.test_input_file(inpath)
     
@@ -217,14 +221,15 @@ class tree:
         # 'Taxon' header is not present in the CSV, so remove all the headers, and add them manually
         consensus = pd.read_csv(inpath, header=0, names=['name', 'x', 'y', 'z'])
 
-        # Like the leaves, we need to sort the consensus points by the name. This is because the leaves
-        # are sorted by name, and we need to make sure that the consensus points are in the same order.
+        # Like the leaves, we need to sort the consensus points by the name. This is
+        # because the leaves are sorted by name, and we need to make sure that the
+        # consensus points are in the same order.
         consensus = consensus.sort_values(by='name')
 
         consensus['name'] = consensus['name'].str.replace(' ', '_')
 
-        # Rescale consensus points. This is the same scaling that is done in consensus_species.py, so 
-        # if that changes, this needs to change as well.
+        # Rescale consensus points. This is the same scaling that is done in
+        # consensus_species.py, so if that changes, this needs to change as well.
         consensus['x'] = consensus['x'].multiply(common.POSITION_SCALE_FACTOR)
         consensus['y'] = consensus['y'].multiply(common.POSITION_SCALE_FACTOR)
         consensus['z'] = consensus['z'].multiply(common.POSITION_SCALE_FACTOR)
@@ -270,17 +275,18 @@ class tree:
 
     def process_branches(self, datainfo):
         '''
-        Create the lines (branches) for a tree.
-        This creates a file of "mesh" statements, used to draw the lines, and
-        a dat file that OpenSpace needs to attach each line with an identifier.
+        Create the lines (branches) for a tree. This creates a file of "mesh" statements,
+        used to draw the lines, and a dat file that OpenSpace needs to attach each line
+        with an identifier.
 
         Input: 
-            dict(datainfo)
-            datainfo['dir'].branches.csv: file with the pairs of points that make up each line
+            dict(datainfo) datainfo['dir'].branches.csv: file with the pairs of points
+            that make up each line
 
         Output:
-            datainfo['dir']_branches.speck: Series of "mesh" commands that will draw a line in OpenSpace.
-            datainfo['dir']_branches.dat: a "key" file that is used by OpenSpace under the hood.
+            datainfo['dir']_branches.speck: Series of "mesh" commands that will draw a
+            line in OpenSpace. datainfo['dir']_branches.dat: a "key" file that is used by
+            OpenSpace under the hood.
         '''
 
 
@@ -333,13 +339,6 @@ class tree:
         # Report to stdout
         common.out_file_message(outpath_speck)
         common.out_file_message(outpath_dat)
-
-
-
-
-
-
-
 
 
     def make_asset_branches(self, datainfo):
@@ -647,6 +646,141 @@ class tree:
             common.out_file_message(outpath)
             print()
 
+
+    def make_asset_internal(self, datainfo):
+        '''
+        Generate the asset file for the tree.
+        
+        Input: 
+            dict(datainfo)
+
+        Output:
+            datainfo['dir']_internal.asset
+        '''
+
+        # We shift the stdout to our filehandle so that we don't have to keep putting
+        # the filehandle in every print statement.
+        # Save the original stdout so we can switch back later
+        original_stdout = sys.stdout
+
+        # Define the main dict that will hold all the info needed per file
+        # This is a nested dict with the format:
+        #      { path: { root:  , filevar:  , os_variable:  , os_identifier:  , name:  } }
+        asset_info = {}
+
+        # Gather info about the files
+        # Get a listing of the speck files in the path, then set the dict
+        # values based on the filename.
+        path = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY
+
+        file = path.name
+
+        # Set the nested dict
+        asset_info[file] = {}
+
+        asset_info[file]['csv_file'] = datainfo['dir'] + '_internal.csv'
+        asset_info[file]['csv_var'] = common.file_variable_generator(asset_info[file]['csv_file'])
+
+        #asset_info[file]['label_file'] = path.stem + '.label'
+        #asset_info[file]['label_var'] = common.file_variable_generator(asset_info[file]['label_file'])
+
+        #asset_info[file]['cmap_file'] = path.stem + '.cmap'
+        #asset_info[file]['cmap_var'] = common.file_variable_generator(asset_info[file]['cmap_file'])
+
+        #asset_info[file]['dat_file'] = path.stem + '.dat'
+        #asset_info[file]['dat_var'] = common.file_variable_generator(asset_info[file]['dat_file'])
+
+        asset_info[file]['asset_rel_path'] = '.'
+
+        asset_info[file]['os_scenegraph_var'] = datainfo['dir'] + '_' + common.TREE_DIRECTORY + '_internal'
+        asset_info[file]['os_identifier_var'] = datainfo['dir'] + '_' + common.TREE_DIRECTORY + '_internal'
+
+        asset_info[file]['gui_name'] = 'Clades'
+        asset_info[file]['gui_path'] = '/' + datainfo['sub_project'] + '/' + common.TREE_DIRECTORY.replace('_', ' ').title()
+
+
+
+        # Open the file to write to
+        outfile = datainfo['dir'] + '_internal.asset'
+        outpath = Path.cwd() / datainfo['dir'] / common.TREE_DIRECTORY / outfile
+        with open(outpath, 'wt') as asset:
+
+            # Switch stdout to the file
+            sys.stdout = asset
+
+            print('-- ' + datainfo['project'] + ' / ' + datainfo['data_group_title'])
+            print("-- This file is auto-generated in the " + self.make_asset_internal.__name__ + "() function inside " + Path(__file__).name)
+            print('-- Author: Brian Abbott <abbott@amnh.org>')
+            print()
+
+            for file in asset_info:
+                print('local ' + asset_info[file]['csv_var'] + ' = asset.resource("' + asset_info[file]['asset_rel_path'] + '/' + asset_info[file]['csv_file'] + '")')
+
+            print('-- Set some parameters for OpenSpace settings')
+            print('local scale_factor = ' + common.POINT_SCALE_FACTOR)
+            print('local scale_exponent = ' + common.POINT_SCALE_EXPONENT)
+            print('local text_size = ' + common.TEXT_SIZE)
+            print('local text_min_size = ' + common.TEXT_MIN_SIZE)
+            print('local text_max_size = ' + common.TEXT_MAX_SIZE)
+            print()
+
+            for file in asset_info:
+
+                print('local ' + asset_info[file]['os_scenegraph_var'] + ' = {')
+                print('    Identifier = "' + asset_info[file]['os_identifier_var'] + '",')
+                print('    Renderable = {')
+                print('        UseCaching = false,')
+                print('        Type = "RenderablePointCloud",')
+                print('         Coloring = {')
+                print('            FixedColor = { 0.8, 0.8, 0.8 }')
+                print('        },')
+                print('        Opacity = 1.0,')
+                print('        SizeSettings = { ScaleFactor = scale_factor, ScaleExponent = scale_exponent },')
+                print('        File = ' + asset_info[file]['csv_var'] + ',')
+                print('        DataMapping = { Name="name"},')
+                print('        Labels = { Enabled = false, Size = text_size  },')
+                print('        --FadeLabelDistances = { 0.0, 0.5 },')
+                print('        --FadeLabelWidths = { 0.001, 0.5 },')
+                print('        Unit = "Km",')
+                print('        BillboardMinMaxSize = { 0.0, 25.0 },')
+                print('        EnablePixelSizeControl = true,')
+                print('        EnableLabelFading = false,')
+                print('        Enabled = false')
+                print('    },')
+                print('    GUI = {')
+                print('        Name = "' + asset_info[file]['gui_name'] + '",')
+                print('        Path = "' + asset_info[file]['gui_path'] + '",')
+                print('    }')
+                print('}')
+                print()
+
+
+
+            print('asset.onInitialize(function()')
+            for file in asset_info:
+                print('    openspace.addSceneGraphNode(' + asset_info[file]['os_scenegraph_var'] + ')')
+
+            print('end)')
+            print()
+
+
+            print('asset.onDeinitialize(function()')
+            for file in asset_info:
+                print('    openspace.removeSceneGraphNode(' + asset_info[file]['os_scenegraph_var'] + ')')
+            
+            print('end)')
+            print()
+
+
+            for file in asset_info:
+                print('asset.export(' + asset_info[file]['os_scenegraph_var'] + ')')
+
+            # Switch the stdout back to normal stdout (screen)
+            sys.stdout = original_stdout
+
+            # Report to stdout
+            common.out_file_message(outpath)
+            print()
 
 
     def make_asset_leaves_interpolated(self, datainfo):


### PR DESCRIPTION
Working internal node labels. Only those nodes *not* named 'internalXX' are shown; it's assumed that anything without that name is a programatically inserted node.

This will fall down if there's a taxon somewhere with the name 'internal' in it, like 'Cercopithecus internalis' or some crap like that. No, that's not a real taxon (I hope), I just made it up.

